### PR TITLE
let method not missing backtrace not land in method_missing

### DIFF
--- a/app/helpers/qbrick/admin_helper.rb
+++ b/app/helpers/qbrick/admin_helper.rb
@@ -8,7 +8,11 @@ module Qbrick
     #
     def method_missing(method, *args, &block)
       main_app.send(method, *args, &block)
-    rescue NoMethodError
+    rescue NoMethodError => exception
+      bc = ::ActiveSupport::BacktraceCleaner.new
+      bc.add_silencer { |l| l =~ /#{__FILE__}.+#{__method__}'?/ }
+      bc.clean exception.backtrace
+
       super
     end
 

--- a/app/helpers/qbrick/admin_helper.rb
+++ b/app/helpers/qbrick/admin_helper.rb
@@ -10,7 +10,7 @@ module Qbrick
       main_app.send(method, *args, &block)
     rescue NoMethodError => exception
       bc = ::ActiveSupport::BacktraceCleaner.new
-      bc.add_silencer { |l| l =~ /#{__FILE__}.+#{__method__}'?/ }
+      bc.add_silencer { |l| l =~ /#{__FILE__}.+#{__method__}'?$/ }
       bc.clean exception.backtrace
 
       super


### PR DESCRIPTION
Hi @iphilgood,

this lets backtraces not so messy by having the top backtraces leading in the qbrick `method_missing` method.

Thank you very much,
Alex