### PR TITLE
remove the check on page path presence

### DIFF
--- a/app/helpers/qbrick/cms/pages_helper.rb
+++ b/app/helpers/qbrick/cms/pages_helper.rb
@@ -10,7 +10,7 @@ module Qbrick
       end
 
       def hide_content_tab?(page)
-        page.page_type == Qbrick::PageType::REDIRECT || !page.translated? || !page.persisted? || page.errors.present?
+        page.redirect? || !page.translated? || !page.persisted? || page.errors.present?
       end
     end
   end

--- a/app/models/qbrick/page.rb
+++ b/app/models/qbrick/page.rb
@@ -114,12 +114,12 @@ module Qbrick
     end
 
     def translated?
-      path.present? && title.present? && slug.present?
+      title.present? && slug.present?
     end
 
     def translated_to?(raw_locale)
       locale = raw_locale.to_s.underscore
-      send("path_#{locale}").present? && send("title_#{locale}").present? && send("slug_#{locale}").present?
+      send("title_#{locale}").present? && send("slug_#{locale}").present?
     end
 
     def translated_link_for(locale)


### PR DESCRIPTION
@alexanderadam 

Because we do not save locale in path (formerly url) anymore for root pages the validation fails because of empty path string.

@noelle and me think this is okay so we do not need the presence check anymore.

What do you think?

Thx :relaxed: 