### PR TITLE
link untranslated bricks

### DIFF
--- a/app/controllers/qbrick/cms/admins_controller.rb
+++ b/app/controllers/qbrick/cms/admins_controller.rb
@@ -6,7 +6,7 @@ module Qbrick
       # GET /admins
       # GET /admins.json
       def index
-        @admins = Admin.all
+        @admins = Qbrick::Admin.all
       end
 
       # GET /admins/1
@@ -16,7 +16,7 @@ module Qbrick
 
       # GET /admins/new
       def new
-        @admin = Admin.new
+        @admin = Qbrick::Admin.new
       end
 
       # GET /admins/1/edit
@@ -26,7 +26,7 @@ module Qbrick
       # POST /admins
       # POST /admins.json
       def create
-        @admin = Admin.new(admin_params)
+        @admin = Qbrick::Admin.new(admin_params)
 
         respond_to do |format|
           if @admin.save
@@ -67,7 +67,7 @@ module Qbrick
 
       # Use callbacks to share common setup or constraints between actions.
       def set_admin
-        @admin = Admin.find(params[:id])
+        @admin = Qbrick::Admin.find_by id: params[:id]
       end
 
       # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/qbrick/cms/admins_controller.rb
+++ b/app/controllers/qbrick/cms/admins_controller.rb
@@ -67,7 +67,7 @@ module Qbrick
 
       # Use callbacks to share common setup or constraints between actions.
       def set_admin
-        @admin = Qbrick::Admin.find_by id: params[:id]
+        @admin = Qbrick::Admin.find params[:id]
       end
 
       # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -14,14 +14,17 @@ module CmsHelper
   end
 
   def cms_brick_item(brick_list, type)
-    type_name = type.class_name.constantize.model_name.human
-    link_to type_name, qbrick.new_cms_brick_path(
+    path = qbrick.new_cms_brick_path(
       brick: {
         type: type.class_name,
         brick_list_id: brick_list.id,
         brick_list_type: brick_list.brick_list_type
-      }), remote: true
-  rescue NameError
-    I18n.t type.class_name.underscore, scope: [:activerecord, :models]
+      })
+    type_name = type.class_name.constantize.model_name.human
+
+    link_to type_name, path, remote: true
+  rescue NameError => e
+    title = I18n.t(type.class_name.underscore, scope: %i(activerecord models)) + " (#{e.message})"
+    defined?(path) && path.present? ? link_to(title, path, remote: true) : title
   end
 end

--- a/app/helpers/qbrick/cms/admin_helper.rb
+++ b/app/helpers/qbrick/cms/admin_helper.rb
@@ -3,7 +3,7 @@ module Qbrick
   module Cms
     module AdminHelper
       def render_language_switch?
-        I18n.available_locales.size > 1
+        I18n.available_locales.many?
       end
 
       def link_to_content_locale(locale)

--- a/app/views/qbrick/cms/backend/_brick_type_dropdown.html.haml
+++ b/app/views/qbrick/cms/backend/_brick_type_dropdown.html.haml
@@ -1,6 +1,6 @@
-- unless brick_list.brick_types.empty?
+- unless brick_list.brick_types.allowed.empty?
   .btn-group
-    - if brick_list.brick_types.allowed.count > 1
+    - if brick_list.brick_types.allowed.many?
       %a.btn.btn-small.btn-primary.dropdown-toggle{ 'data-toggle' => 'dropdown', 'href' => '#' }
         = t('.add_element')
         %span.caret
@@ -12,4 +12,4 @@
           .divider
     - else
       - brick_list.brick_types.allowed.each do |type|
-        = link_to t('.add_specific_element', :name => type.class_name.constantize.model_name.human), qbrick.new_cms_brick_path(:brick => { :type => type.class_name, :brick_list_id => brick_list.id, :brick_list_type => brick_list.brick_list_type }), :remote => true, :class => 'btn btn-small btn-primary'
+        = link_to t('.add_specific_element', name: type.class_name.constantize.model_name.human), qbrick.new_cms_brick_path(brick: { type: type.class_name, brick_list_id: brick_list.id, brick_list_type: brick_list.brick_list_type }), remote: true, class: 'btn btn-small btn-primary'

--- a/app/views/qbrick/cms/backend/_empty_state.html.haml
+++ b/app/views/qbrick/cms/backend/_empty_state.html.haml
@@ -2,4 +2,4 @@
   .centered.empty-state
     .muted= t('.empty')
     .btn-group
-      = render 'brick_type_dropdown', :brick_list => brick
+      = render 'brick_type_dropdown', brick_list: brick

--- a/app/views/qbrick/cms/backend/_main_navigation.html.haml
+++ b/app/views/qbrick/cms/backend/_main_navigation.html.haml
@@ -1,9 +1,9 @@
-= link_to 'Qbrick CMS', qbrick.cms_root_path, :class => 'brand'
+= link_to 'Qbrick CMS', qbrick.cms_root_path, class: 'brand'
 
 %ul.nav.pull-right.language-navigation
   - if render_language_switch?
     - I18n.available_locales.each do |locale|
-      %li{ :class => (:active if I18n.locale.to_s == locale.to_s) }
+      %li{ class: (:active if I18n.locale.to_s == locale.to_s) }
         = link_to_content_locale(locale)
 
   %li.dropdown
@@ -12,9 +12,9 @@
       %b.caret
     %ul.dropdown-menu
       %li= link_to t('.change_password'), qbrick.edit_cms_account_path
-      %li= link_to t('.logout'), qbrick.destroy_admin_session_path, :method => :delete
+      %li= link_to t('.logout'), qbrick.destroy_admin_session_path, method: :delete
 
 %ul.nav
   %li= link_to t('.settings'), qbrick.cms_settings_collections_path
-  %li= link_to Qbrick::Page.model_name.human(:count => 2), qbrick.cms_pages_path
-  %li= link_to Qbrick::Admin.model_name.human(:count => 2), qbrick.cms_admins_path
+  %li= link_to Qbrick::Page.model_name.human(count: 2), qbrick.cms_pages_path
+  %li= link_to Qbrick::Admin.model_name.human(count: 2), qbrick.cms_admins_path

--- a/app/views/qbrick/cms/bricks/_brick_header.html.haml
+++ b/app/views/qbrick/cms/bricks/_brick_header.html.haml
@@ -12,9 +12,9 @@
     - if brick.persisted?
 
       - # addable child dropdown menu
-      - if brick.respond_to?(:brick_list)
+      - if brick.respond_to? :brick_list
         .btn-group
-          = render('brick_type_dropdown', brick_list: brick)
+          = render 'brick_type_dropdown', brick_list: brick
 
       - # grid selection
       - if brick.class.include? Qbrick::Gridded
@@ -24,7 +24,7 @@
             %span.caret
           %ul.dropdown-menu.pull-right
             %li
-              = form.input :col_count, collection: brick.class.available_grid_sizes, as: :radio_buttons, label_method: lambda { |col_count| t("qbrick.cms.bricks.columns", count: col_count) }
+              = form.input :col_count, collection: brick.class.available_grid_sizes, as: :radio_buttons, label_method: lambda { |col_count| t('qbrick.cms.bricks.columns', count: col_count) }
 
       - # possible styles
       - unless brick.available_display_styles.empty?


### PR DESCRIPTION
Hi @noelle & @iphilgood,

this adds explicitly the `Qbrick` namespace on `Admin` model access and makes brick links if there was something wrong with naming (plus adds the error messages in brackets, transparently) and changes.

Thank you very much,
Alex